### PR TITLE
iminuit 2.8.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,23 +11,25 @@ source:
 
 build:
   number: 0
+  # This package doesn't included in the SOW Packages on s390x
+  skip: True  # [s390x]
+  skip: True  # [py<36]
   script:
     - export CMAKE_BUILD_PARALLEL_LEVEL=${CPU_COUNT}
     - {{ PYTHON }} -m pip install . -vvv
 
 requirements:
   build:
-    - python                   # [build_platform != target_platform]
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - cmake
     - make  # [unix]
   host:
-    - python >=3.6
+    - python
     - pip
     - setuptools >=42
     - wheel
-    - {{ pin_compatible('numpy') }}
+    - numpy
   run:
     - python >=3.6
     # use cibuildwheels to make wheels (#512) https://github.com/scikit-hep/iminuit/pull/512

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "iminuit" %}
-{% set version = "2.7.0" %}
+{% set version = "2.8.4" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: ff2183814c5c3a1cfa77355249bb3706e06e886c9a07b00267ff3088ce58e5b3
+  sha256: 4b09189f3094896cfc68596adc95b7f1d92772e1de1424e5dc4dd81def56e8b0
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - wheel
     - numpy
   run:
-    - python >=3.6
+    - python
     # use cibuildwheels to make wheels (#512) https://github.com/scikit-hep/iminuit/pull/512
     - {{ pin_compatible('numpy') }}
 


### PR DESCRIPTION
Update iminuit to 2.8.4

Version change: bump version number from 2.7.0 to 2.8.4
Bug Tracker: new open issues https://github.com/scikit-hep/iminuit/issues
Upstream license:  License file:  https://github.com/scikit-hep/iminuit/blob/master/LICENSE
Changelog: https://iminuit.readthedocs.io/en/stable/changelog.html
Upstream pyproject.toml: https://github.com/scikit-hep/iminuit/blob/v2.8.4/pyproject.toml
Upstream setup file: https://github.com/scikit-hep/iminuit/blob/v2.8.4/setup.cfg

Actions:
1. Skip s390x (it's not included in SOW Packages)
2. Skip py<36

Result:
- all-succeeded
