### PR TITLE
2.18.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ build:
   skip: True  # [py<37]
   script:
     - export CMAKE_BUILD_PARALLEL_LEVEL=${CPU_COUNT}
-    - {{ PYTHON }} -m pip install . -vvv
+    - {{ PYTHON }} -m pip install . -vvv --no-deps
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ build:
   number: 0
   # This package doesn't included in the SOW Packages on s390x
   skip: True  # [s390x]
-  skip: True  # [py<36]
+  skip: True  # [py<37]
   script:
     - export CMAKE_BUILD_PARALLEL_LEVEL=${CPU_COUNT}
     - {{ PYTHON }} -m pip install . -vvv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "iminuit" %}
-{% set version = "2.8.4" %}
+{% set version = "2.18.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 4b09189f3094896cfc68596adc95b7f1d92772e1de1424e5dc4dd81def56e8b0
+  sha256: 7ee2c6a0bcdac581b38fae8d0f343fdee55f91f1f6a6cc9643fcfbcc6c2dc3e6
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -62,7 +62,7 @@ about:
     Minuit. iminuit is mostly compatible with PyMinuit (with few exceptions).
     Existing PyMinuit code can be ported to iminuit by just changing the
     import statement.
-  doc_url: http://iminuit.readthedocs.io
+  doc_url: https://iminuit.readthedocs.io
   dev_url: https://github.com/scikit-hep/iminuit
 
 extra:


### PR DESCRIPTION
# iminuit 2.18.0

upstream: https://github.com/scikit-hep/iminuit/tree/v2.18.0
jira: https://anaconda.atlassian.net/browse/PKG-1042
`pyproject.toml`: https://github.com/scikit-hep/iminuit/blob/v2.18.0/pyproject.toml
release notes: https://github.com/scikit-hep/iminuit/releases/tag/v2.18.0
license: https://github.com/scikit-hep/iminuit/blob/v2.18.0/LICENSE

## Changes
- Bump version and SHA
- Add `--no-deps` to setup call
- Remove python 3.6 support ([link](https://github.com/scikit-hep/iminuit/pull/792))

## Notes
- This adds python 3.11 support
