### PR TITLE
v2.30.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,9 @@ source:
 build:
   number: 0
   script:
-    - export CMAKE_BUILD_PARALLEL_LEVEL=${CPU_COUNT}
+    - export CMAKE_BUILD_PARALLEL_LEVEL=${CPU_COUNT}  # [unix]
+    - set CMAKE_BUILD_PARALLEL_LEVEL=%CPU_COUNT%      # [win]
+    - set CMAKE_GENERATOR=Ninja                       # [win]
     - {{ PYTHON }} -m pip install . -vvv --no-deps --no-build-isolation
 
 requirements:
@@ -21,6 +23,7 @@ requirements:
     - {{ compiler('cxx') }}
     - cmake
     - make  # [unix]
+    - ninja-base  # [win]
   host:
     - python
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,8 @@ requirements:
     - pip
     - setuptools
     - wheel
-    - numpy
+    - numpy 2.0 # [py<313]
+    - numpy 2.1 # [py==313]
     - pybind11 >=2.12
     - scikit-build-core
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "iminuit" %}
-{% set version = "2.18.0" %}
+{% set version = "2.30.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,16 +7,15 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 7ee2c6a0bcdac581b38fae8d0f343fdee55f91f1f6a6cc9643fcfbcc6c2dc3e6
+  sha256: 2815bfdeb8e7f78185f316b75e2d4b19d0f6993bdc5ff03352ed37b70a796360
 
 build:
   number: 0
   # This package doesn't included in the SOW Packages on s390x
   skip: True  # [s390x]
-  skip: True  # [py<37]
   script:
     - export CMAKE_BUILD_PARALLEL_LEVEL=${CPU_COUNT}
-    - {{ PYTHON }} -m pip install . -vvv --no-deps
+    - {{ PYTHON }} -m pip install . -vvv --no-deps --no-build-isolation
 
 requirements:
   build:
@@ -27,13 +26,14 @@ requirements:
   host:
     - python
     - pip
-    - setuptools >=42
+    - setuptools
     - wheel
     - numpy
+    - pybind11>=2.12
+    - scikit-build-core
   run:
     - python
-    # use cibuildwheels to make wheels (#512) https://github.com/scikit-hep/iminuit/pull/512
-    - {{ pin_compatible('numpy') }}
+    - numpy >=1.21
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,6 +16,8 @@ build:
     - set CMAKE_BUILD_PARALLEL_LEVEL=%CPU_COUNT%      # [win]
     - set CMAKE_GENERATOR=Ninja                       # [win]
     - {{ PYTHON }} -m pip install . -vvv --no-deps --no-build-isolation
+  missing_dso_whitelist:  # [s390x]
+    - $RPATH/ld64.so.1  # [s390x]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,8 +11,6 @@ source:
 
 build:
   number: 0
-  # This package doesn't included in the SOW Packages on s390x
-  skip: True  # [s390x]
   script:
     - export CMAKE_BUILD_PARALLEL_LEVEL=${CPU_COUNT}
     - {{ PYTHON }} -m pip install . -vvv --no-deps --no-build-isolation
@@ -29,7 +27,7 @@ requirements:
     - setuptools
     - wheel
     - numpy
-    - pybind11>=2.12
+    - pybind11 >=2.12
     - scikit-build-core
   run:
     - python


### PR DESCRIPTION
iminuit v2.30.1

**Destination channel:**  defaults

### Links

- [PKG-6380](https://anaconda.atlassian.net/browse/PKG-6380) 
- [Upstream repository](https://github.com/scikit-hep/iminuit/tree/v2.30.1)
- [pyproject.toml](https://github.com/scikit-hep/iminuit/blob/v2.30.1/pyproject.toml)


### Explanation of changes:

- Bump version and SHA
- Build for python 3.13
- Build for s390x
- Update dependencies
- Use Ninja on Windows. 

### Notes:
- There is a v2.30.2 on Github but it only consists of doc changes and hasn't been uploaded to PyPI
- Windows fails when trying to sign with the test cert. You can see the build and tests all passed. The merge builds are not  impacted by this. 


[PKG-6380]: https://anaconda.atlassian.net/browse/PKG-6380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ